### PR TITLE
Bug not clearing firefinder-match class when filtering

### DIFF
--- a/chrome/content/firebug.js
+++ b/chrome/content/firebug.js
@@ -61,15 +61,24 @@ FBL.ns(function () {
 				return tabIndex;
 			},
 			getFirefinderState = function () {
-				var tabIndex = getTabIndex(),
-					state = statesFirefinder[tabIndex];
-				if (!state || !state[tabIndex]) {
-					state = statesFirefinder[getTabIndex()] = {
-						matchingElements : []
-					};
-				}	
-				return state;	
+			    var tabIndex = getTabIndex(),
+			        state = statesFirefinder[tabIndex],
+			        matchingElementsExists = false;
+
+
+			    try {
+			        matchingElementsExists = state.matchingElements.length + "";
+			    } catch(e) {}
+
+			    if (!state || !matchingElementsExists) {
+			        state = statesFirefinder[tabIndex] = {
+			            matchingElements : []
+			        };
+			    }   
+
+			    return state;   
 			};
+
 		
 		Firebug.firefinderModel = extend(Firebug.Module, {
 			baseContentAdded : false,


### PR DESCRIPTION
## Context

Due to an incorrect check in the initial **firefinder** state, **firefinder** failed to reinitialize its state (`state` is an object and not an array, thus checking on `tabIndex` is incorrect). See [Firefinder group thread](https://groups.google.com/forum/?fromgroups=#!topic/firefinder/Z5ads1ZdI9Q).
## Correction

We here check if the property `matchingElements` of `state` is existing or not. 
But due to some a strange behaviour of Firefox, the only way to test the existence of this field is to test its length, and thus should be embedded in a `try... catch` block.
