### PR TITLE
Fix problem with reload page. (F5) 

### DIFF
--- a/chrome/content/firebug.js
+++ b/chrome/content/firebug.js
@@ -432,10 +432,12 @@ FBL.ns(function () {
 				// Clear previosuly matched elements' CSS classes	
 				for (var i=0, il=matchingElements.length, elm; i<il; i++) {
 					elm = matchingElements[i];
-					elm.className = elm.className.replace(regExpClass, "").replace(regExpSpaceFix, "");
-					if (elm.className.length === 0) {
-						elm.removeAttribute("class");
-					}
+					try {
+						elm.className = elm.className.replace(regExpClass, "").replace(regExpSpaceFix, "");
+						if (elm.className.length === 0) {
+							elm.removeAttribute("class");
+						}
+					} catch(e) {}
 				}				
 				return state;		
 			}


### PR DESCRIPTION
Firefinder has stopped working whenever the page was reloaded on my single page app. The problem was probably with the invalid access to state.matchingElements[]. I've wrapped it by try{}catch{} block.
